### PR TITLE
Added babel-runtime as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "test:watch": "nwb test --server",
     "prepublishOnly": "yarn build"
   },
-  "dependencies": {},
+  "dependencies": {
+    "babel-runtime": "^6.26.0"
+  },
   "devDependencies": {
     "eslint-config-react-tools": "^1.1.1",
     "nwb": "0.21.x"


### PR DESCRIPTION
Since nwb doesn't work with babel 7 yet ( https://github.com/insin/nwb/issues/403 ), the babel-runtime should be included as it is being required by the output of this lib.

Also see https://github.com/nozzle/react-static/issues/685